### PR TITLE
adapt language pack to version 4.0.x of attachments

### DIFF
--- a/attachments-French-fr-FR/attachments_fr_fr_language_pack.xml
+++ b/attachments-French-fr-FR/attachments_fr_fr_language_pack.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<extension version="2.5" type="file" method="upgrade">
+<extension type="file" version="4.0" method="upgrade">
   <name>attachments_fr_fr_language_pack</name>
-  <version>3.1.1</version>
+  <version>4.0.4</version>
   <creationDate>2014-02-17</creationDate>
   <author>Jonathan M. Cameron, Didier Lan (3.1, 3.1 help page), Maël Boureux (3.1), Marc-André Ladouceur (2.0, 3.0), Yann Kerviel (3.0), and Pascal Adalian (1.3.4)</author>
   <authorEmail>jmcameron@jmcameron.net</authorEmail>
@@ -81,7 +81,7 @@
     </files>
 
     <!-- Attachments attachments plugin framework language files -->
-    <files folder="attachments_plugin_framework" target="plugins/attachments/attachments_plugin_framework/language/fr-FR">
+    <files folder="attachments_plugin_framework" target="plugins/attachments/framework/language/fr-FR">
       <filename>index.html</filename>
       <filename>fr-FR.plg_attachments_attachments_plugin_framework.ini</filename>
       <filename>fr-FR.plg_attachments_attachments_plugin_framework.sys.ini</filename>

--- a/attachments-French-fr-FR/install.php
+++ b/attachments-French-fr-FR/install.php
@@ -16,6 +16,7 @@ defined('_JEXEC') or die('Restricted access');
 // Import the component helper
 jimport('joomla.application.component.helper');
 
+use JMCameron\Component\Attachments\Site\Helper\AttachmentsDefines;
 
 /**
  * The attachments language installation class
@@ -39,7 +40,7 @@ class attachments_fr_fr_language_packInstallerScript
 		$lang->load('files_attachments_language_pack.install', dirname(__FILE__));
 
 		// Verify that the Joomla version is adequate
-		$this->minimum_joomla_release = $parent->get( 'manifest' )->attributes()->version;		  
+		$this->minimum_joomla_release = $parent->getManifest()->version;
 		if ( version_compare(JVERSION, $this->minimum_joomla_release, 'lt') ) {
 			$msg = JText::sprintf('ATTACHMENTS_LANGUAGE_PACK_ERROR_INADEQUATE_JOOMLA_VERSION_S',
 								  $this->minimum_joomla_release);
@@ -62,13 +63,14 @@ class attachments_fr_fr_language_packInstallerScript
 
 		// Verify that the attachments version is adequate
 		// (Do not update language pack for old versions of Attachments)
-		require_once(JPATH_SITE.'/components/com_attachments/defines.php');
-		$min_version = '3.0.9';
-		if (version_compare(AttachmentsDefines::$ATTACHMENTS_VERSION, '3.0.9', 'lt'))
+		require_once(JPATH_SITE . '/components/com_attachments/src/Helper/AttachmentsDefines.php');
+		$min_version = '4.0.4';
+		if (version_compare(AttachmentsDefines::$ATTACHMENTS_VERSION, $min_version, 'lt'))
 		{
-			$msg = JText::sprintf('ATTACHMENTS_LANGUAGE_PACK_ERROR_ATTACHMENTS_TOO_OLD_S', '3.1');
+			$msg = JText::sprintf('ATTACHMENTS_LANGUAGE_PACK_ERROR_ATTACHMENTS_TOO_OLD_S', $min_version);
 			$app->enqueueMessage('<br/>', 'error');
 			$app->enqueueMessage($msg, 'error');
+			$app->enqueueMessage(sprintf('Version: %s', AttachmentsDefines::$ATTACHMENTS_VERSION), 'error');
 			$app->enqueueMessage('<br/>', 'error');
 			return false;
 		}


### PR DESCRIPTION
I want to be able to adapt language pack to new joomla 4.0.x and above and corresponding attachments component version
@jmcameron could you please give me access and to @parapente as for component to be able to push to main